### PR TITLE
fix: arch-creator.sh now use bash instead of sh

### DIFF
--- a/arch-creator.sh
+++ b/arch-creator.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 DEFAULT_IMAGE="${SALT_PREFIX:-"archlinux"}"
 SALT_ENV="${SALT_ENV:-"base"}"


### PR DESCRIPTION
Bash is required to run arch-creator.sh and we should not assume all shells builtins are implemented by /bin/sh